### PR TITLE
Updated fix-yahoo-finance to yfinance

### DIFF
--- a/Python_Stock/Annual_Returns.ipynb
+++ b/Python_Stock/Annual_Returns.ipynb
@@ -17,8 +17,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Basic_Machine_Learning_Predicts.ipynb
+++ b/Python_Stock/Basic_Machine_Learning_Predicts.ipynb
@@ -20,7 +20,7 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "import fix_yahoo_finance as yf\n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Big_Three_Trading Strategy.ipynb
+++ b/Python_Stock/Big_Three_Trading Strategy.ipynb
@@ -29,8 +29,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Oil_Prediction.ipynb
+++ b/Python_Stock/Oil_Prediction.ipynb
@@ -24,7 +24,7 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
+        "# yfinance is used to fetch data \n",
         "import yfinance as yf\n",
         "yf.pdr_override()"
       ],

--- a/Python_Stock/Portfolio_Analysis.ipynb
+++ b/Python_Stock/Portfolio_Analysis.ipynb
@@ -18,8 +18,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Portfolio_Strategies/AI_Learning_Portfolio.ipynb
+++ b/Python_Stock/Portfolio_Strategies/AI_Learning_Portfolio.ipynb
@@ -19,7 +19,7 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
+        "# yfinance is used to fetch data \n",
         "import yfinance as yf\n",
         "yf.pdr_override()"
       ],

--- a/Python_Stock/Portfolio_Strategies/Aerospace_Defense_Portfolio.ipynb
+++ b/Python_Stock/Portfolio_Strategies/Aerospace_Defense_Portfolio.ipynb
@@ -19,7 +19,7 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
+        "# yfinance is used to fetch data \n",
         "import yfinance as yf\n",
         "yf.pdr_override()"
       ],

--- a/Python_Stock/Portfolio_Strategies/Airlines_Portfolio.ipynb
+++ b/Python_Stock/Portfolio_Strategies/Airlines_Portfolio.ipynb
@@ -19,7 +19,7 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
+        "# yfinance is used to fetch data \n",
         "import yfinance as yf\n",
         "yf.pdr_override()"
       ],

--- a/Python_Stock/Portfolio_Strategies/Banks_Portfolio.ipynb
+++ b/Python_Stock/Portfolio_Strategies/Banks_Portfolio.ipynb
@@ -26,8 +26,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Portfolio_Strategies/Big_Data_Portfolio.ipynb
+++ b/Python_Stock/Portfolio_Strategies/Big_Data_Portfolio.ipynb
@@ -19,8 +19,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Portfolio_Strategies/Biotech_Portfolio.ipynb
+++ b/Python_Stock/Portfolio_Strategies/Biotech_Portfolio.ipynb
@@ -19,8 +19,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Portfolio_Strategies/Cloud_Services_Portfolio.ipynb
+++ b/Python_Stock/Portfolio_Strategies/Cloud_Services_Portfolio.ipynb
@@ -19,8 +19,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Portfolio_Strategies/Commodity_Portfolio.ipynb
+++ b/Python_Stock/Portfolio_Strategies/Commodity_Portfolio.ipynb
@@ -29,8 +29,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Portfolio_Strategies/Coronavirus_Portfolio.ipynb
+++ b/Python_Stock/Portfolio_Strategies/Coronavirus_Portfolio.ipynb
@@ -19,7 +19,7 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
+        "# yfinance is used to fetch data \n",
         "import yfinance as yf\n",
         "yf.pdr_override()"
       ],

--- a/Python_Stock/Portfolio_Strategies/Cruises_Portfolio.ipynb
+++ b/Python_Stock/Portfolio_Strategies/Cruises_Portfolio.ipynb
@@ -19,7 +19,7 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
+        "# yfinance is used to fetch data \n",
         "import yfinance as yf\n",
         "yf.pdr_override()"
       ],

--- a/Python_Stock/Portfolio_Strategies/Dividends_Portfolio.ipynb
+++ b/Python_Stock/Portfolio_Strategies/Dividends_Portfolio.ipynb
@@ -28,8 +28,8 @@
         "\n",
         "# fetch dividend\n",
         "import yfinance as yfd\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Portfolio_Strategies/Electric_Car_Portfolio.ipynb
+++ b/Python_Stock/Portfolio_Strategies/Electric_Car_Portfolio.ipynb
@@ -29,8 +29,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Portfolio_Strategies/Factor_Analysis.ipynb
+++ b/Python_Stock/Portfolio_Strategies/Factor_Analysis.ipynb
@@ -19,8 +19,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Portfolio_Strategies/Long_term_SPY.ipynb
+++ b/Python_Stock/Portfolio_Strategies/Long_term_SPY.ipynb
@@ -43,8 +43,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Portfolio_Strategies/Market_Portfolio.ipynb
+++ b/Python_Stock/Portfolio_Strategies/Market_Portfolio.ipynb
@@ -29,8 +29,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Portfolio_Strategies/Obama_Stock_Portfolio.ipynb
+++ b/Python_Stock/Portfolio_Strategies/Obama_Stock_Portfolio.ipynb
@@ -29,8 +29,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Portfolio_Strategies/Obama_Stock_Portfolio_Coals.ipynb
+++ b/Python_Stock/Portfolio_Strategies/Obama_Stock_Portfolio_Coals.ipynb
@@ -29,8 +29,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Portfolio_Strategies/Optimal_Portfolio.ipynb
+++ b/Python_Stock/Portfolio_Strategies/Optimal_Portfolio.ipynb
@@ -20,8 +20,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Portfolio_Strategies/Portfolio_Functions.ipynb
+++ b/Python_Stock/Portfolio_Strategies/Portfolio_Functions.ipynb
@@ -19,8 +19,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Portfolio_Strategies/Protective_Mask_Maker_Portfolio.ipynb
+++ b/Python_Stock/Portfolio_Strategies/Protective_Mask_Maker_Portfolio.ipynb
@@ -19,7 +19,7 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
+        "# yfinance is used to fetch data \n",
         "import yfinance as yf\n",
         "yf.pdr_override()"
       ],

--- a/Python_Stock/Portfolio_Strategies/Risk_Returns_Portfolio.ipynb
+++ b/Python_Stock/Portfolio_Strategies/Risk_Returns_Portfolio.ipynb
@@ -19,8 +19,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Portfolio_Strategies/The_Dave_Ramsey_Portfolio.ipynb
+++ b/Python_Stock/Portfolio_Strategies/The_Dave_Ramsey_Portfolio.ipynb
@@ -50,8 +50,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Portfolio_Strategies/Toilet_Paper_Portfolio.ipynb
+++ b/Python_Stock/Portfolio_Strategies/Toilet_Paper_Portfolio.ipynb
@@ -19,7 +19,7 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
+        "# yfinance is used to fetch data \n",
         "import yfinance as yf\n",
         "yf.pdr_override()"
       ],

--- a/Python_Stock/Portfolio_Strategies/Trump_Stock_Portfolio.ipynb
+++ b/Python_Stock/Portfolio_Strategies/Trump_Stock_Portfolio.ipynb
@@ -29,8 +29,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Portfolio_Strategies/US_Treasury.ipynb
+++ b/Python_Stock/Portfolio_Strategies/US_Treasury.ipynb
@@ -44,8 +44,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Portfolio_Strategies/Vaccine_Portfolio.ipynb
+++ b/Python_Stock/Portfolio_Strategies/Vaccine_Portfolio.ipynb
@@ -19,7 +19,7 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
+        "# yfinance is used to fetch data \n",
         "import yfinance as yf\n",
         "yf.pdr_override()"
       ],

--- a/Python_Stock/Portfolio_Strategies/Ventilator_Manufacturer_Portfolio.ipynb
+++ b/Python_Stock/Portfolio_Strategies/Ventilator_Manufacturer_Portfolio.ipynb
@@ -19,7 +19,7 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
+        "# yfinance is used to fetch data \n",
         "import yfinance as yf\n",
         "yf.pdr_override()"
       ],

--- a/Python_Stock/Profit_Loss.ipynb
+++ b/Python_Stock/Profit_Loss.ipynb
@@ -27,8 +27,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/StockReturnsAnalysis.ipynb
+++ b/Python_Stock/StockReturnsAnalysis.ipynb
@@ -22,8 +22,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Stock_Alpha_Beta.ipynb
+++ b/Python_Stock/Stock_Alpha_Beta.ipynb
@@ -26,8 +26,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Stock_Analysis_Returns.ipynb
+++ b/Python_Stock/Stock_Analysis_Returns.ipynb
@@ -20,7 +20,7 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "import fix_yahoo_finance as yf\n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Stock_Basic_Statistics.ipynb
+++ b/Python_Stock/Stock_Basic_Statistics.ipynb
@@ -28,8 +28,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Stock_Columns.ipynb
+++ b/Python_Stock/Stock_Columns.ipynb
@@ -17,7 +17,7 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "import fix_yahoo_finance as yf\n",
+        "import yfinance as yf\n",
         "from pandas_datareader import data as pdr\n",
         "yf.pdr_override()"
       ],

--- a/Python_Stock/Stock_Correlations.ipynb
+++ b/Python_Stock/Stock_Correlations.ipynb
@@ -29,8 +29,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Stock_Data_Science_Python.ipynb
+++ b/Python_Stock/Stock_Data_Science_Python.ipynb
@@ -25,8 +25,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Stock_Linear_Correlation_Analysis.ipynb
+++ b/Python_Stock/Stock_Linear_Correlation_Analysis.ipynb
@@ -29,7 +29,7 @@
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
         "from pandas_datareader import data as pdr\n",
-        "import fix_yahoo_finance as yf\n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Stock_Linear_Regression.ipynb
+++ b/Python_Stock/Stock_Linear_Regression.ipynb
@@ -18,8 +18,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Stock_RiskAndReturn.ipynb
+++ b/Python_Stock/Stock_RiskAndReturn.ipynb
@@ -31,8 +31,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Stock_Statistics.ipynb
+++ b/Python_Stock/Stock_Statistics.ipynb
@@ -27,8 +27,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Stock_TimeSeries_Forecast.ipynb
+++ b/Python_Stock/Stock_TimeSeries_Forecast.ipynb
@@ -15,7 +15,7 @@
         "import numpy as np\n",
         "import matplotlib.pyplot as plt\n",
         "from fbprophet import Prophet\n",
-        "import fix_yahoo_finance as yf\n",
+        "import yfinance as yf\n",
         "from pandas_datareader import data as pdr"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/ADL.ipynb
+++ b/Python_Stock/Technical_Indicators/ADL.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/ADX.ipynb
+++ b/Python_Stock/Technical_Indicators/ADX.ipynb
@@ -33,8 +33,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/ADXR.ipynb
+++ b/Python_Stock/Technical_Indicators/ADXR.ipynb
@@ -28,8 +28,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/APO.ipynb
+++ b/Python_Stock/Technical_Indicators/APO.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/ATR.ipynb
+++ b/Python_Stock/Technical_Indicators/ATR.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Absolute_Return_Indicator.ipynb
+++ b/Python_Stock/Technical_Indicators/Absolute_Return_Indicator.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Alligators_Gator_Oscillator.ipynb
+++ b/Python_Stock/Technical_Indicators/Alligators_Gator_Oscillator.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Aroon.ipynb
+++ b/Python_Stock/Technical_Indicators/Aroon.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Aroon_Oscillator.ipynb
+++ b/Python_Stock/Technical_Indicators/Aroon_Oscillator.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/BBWidth.ipynb
+++ b/Python_Stock/Technical_Indicators/BBWidth.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/B_indicator.ipynb
+++ b/Python_Stock/Technical_Indicators/B_indicator.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Balance_of_Power.ipynb
+++ b/Python_Stock/Technical_Indicators/Balance_of_Power.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Beta_Indicator.ipynb
+++ b/Python_Stock/Technical_Indicators/Beta_Indicator.ipynb
@@ -17,8 +17,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Breadth_Indicators.ipynb
+++ b/Python_Stock/Technical_Indicators/Breadth_Indicators.ipynb
@@ -38,8 +38,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/CCI.ipynb
+++ b/Python_Stock/Technical_Indicators/CCI.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/CLV.ipynb
+++ b/Python_Stock/Technical_Indicators/CLV.ipynb
@@ -26,8 +26,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/CMF.ipynb
+++ b/Python_Stock/Technical_Indicators/CMF.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Central_Pivot_Range_CPR.ipynb
+++ b/Python_Stock/Technical_Indicators/Central_Pivot_Range_CPR.ipynb
@@ -26,8 +26,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Chaikin_Oscillator.ipynb
+++ b/Python_Stock/Technical_Indicators/Chaikin_Oscillator.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Chandelier_Exit.ipynb
+++ b/Python_Stock/Technical_Indicators/Chandelier_Exit.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Coppock_Curve.ipynb
+++ b/Python_Stock/Technical_Indicators/Coppock_Curve.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Correlation_Coefficient.ipynb
+++ b/Python_Stock/Technical_Indicators/Correlation_Coefficient.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Covariance.ipynb
+++ b/Python_Stock/Technical_Indicators/Covariance.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/DEMA.ipynb
+++ b/Python_Stock/Technical_Indicators/DEMA.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/DMI.ipynb
+++ b/Python_Stock/Technical_Indicators/DMI.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/DPO.ipynb
+++ b/Python_Stock/Technical_Indicators/DPO.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Donchain_Channel.ipynb
+++ b/Python_Stock/Technical_Indicators/Donchain_Channel.ipynb
@@ -25,8 +25,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/EMA.ipynb
+++ b/Python_Stock/Technical_Indicators/EMA.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/EMAV.ipynb
+++ b/Python_Stock/Technical_Indicators/EMAV.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/EWMA.ipynb
+++ b/Python_Stock/Technical_Indicators/EWMA.ipynb
@@ -26,8 +26,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/EWMA_Double.ipynb
+++ b/Python_Stock/Technical_Indicators/EWMA_Double.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/EWMA_Triple.ipynb
+++ b/Python_Stock/Technical_Indicators/EWMA_Triple.ipynb
@@ -17,8 +17,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Ease_Of_Movement.ipynb
+++ b/Python_Stock/Technical_Indicators/Ease_Of_Movement.ipynb
@@ -33,8 +33,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Efficiency_Ratio.ipynb
+++ b/Python_Stock/Technical_Indicators/Efficiency_Ratio.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Elder_Force_Index.ipynb
+++ b/Python_Stock/Technical_Indicators/Elder_Force_Index.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Elder_Ray_Index.ipynb
+++ b/Python_Stock/Technical_Indicators/Elder_Ray_Index.ipynb
@@ -26,8 +26,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Envelopes.ipynb
+++ b/Python_Stock/Technical_Indicators/Envelopes.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Force_Index.ipynb
+++ b/Python_Stock/Technical_Indicators/Force_Index.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/GANN_Lines_Angles.ipynb
+++ b/Python_Stock/Technical_Indicators/GANN_Lines_Angles.ipynb
@@ -27,8 +27,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/GMMA.ipynb
+++ b/Python_Stock/Technical_Indicators/GMMA.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Geometric_Return_Indicator.ipynb
+++ b/Python_Stock/Technical_Indicators/Geometric_Return_Indicator.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Heiken_Ashi.ipynb
+++ b/Python_Stock/Technical_Indicators/Heiken_Ashi.ipynb
@@ -25,8 +25,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\") \n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/High_Minus_Low.ipynb
+++ b/Python_Stock/Technical_Indicators/High_Minus_Low.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Hull_Moving_Average.ipynb
+++ b/Python_Stock/Technical_Indicators/Hull_Moving_Average.ipynb
@@ -27,8 +27,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Ichimoku.ipynb
+++ b/Python_Stock/Technical_Indicators/Ichimoku.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Inverse_Fisher_Transform.ipynb
+++ b/Python_Stock/Technical_Indicators/Inverse_Fisher_Transform.ipynb
@@ -28,8 +28,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/KAMA.ipynb
+++ b/Python_Stock/Technical_Indicators/KAMA.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/KST.ipynb
+++ b/Python_Stock/Technical_Indicators/KST.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Keltners_Channels.ipynb
+++ b/Python_Stock/Technical_Indicators/Keltners_Channels.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Kijun_Sen.ipynb
+++ b/Python_Stock/Technical_Indicators/Kijun_Sen.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Linear_Regression.ipynb
+++ b/Python_Stock/Technical_Indicators/Linear_Regression.ipynb
@@ -26,8 +26,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Linear_Regression_Slope.ipynb
+++ b/Python_Stock/Technical_Indicators/Linear_Regression_Slope.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Linear_Weighted_Moving_Average.ipynb
+++ b/Python_Stock/Technical_Indicators/Linear_Weighted_Moving_Average.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Logarithmic_Return_Indicator.ipynb
+++ b/Python_Stock/Technical_Indicators/Logarithmic_Return_Indicator.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/MACD.ipynb
+++ b/Python_Stock/Technical_Indicators/MACD.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/MAD.ipynb
+++ b/Python_Stock/Technical_Indicators/MAD.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/MA_High_Low.ipynb
+++ b/Python_Stock/Technical_Indicators/MA_High_Low.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/MFI.ipynb
+++ b/Python_Stock/Technical_Indicators/MFI.ipynb
@@ -25,8 +25,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Martin_Pring_Special_K.ipynb
+++ b/Python_Stock/Technical_Indicators/Martin_Pring_Special_K.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Maximum_price.ipynb
+++ b/Python_Stock/Technical_Indicators/Maximum_price.ipynb
@@ -17,8 +17,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/McClellan_Oscillator.ipynb
+++ b/Python_Stock/Technical_Indicators/McClellan_Oscillator.ipynb
@@ -25,8 +25,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Median_Price.ipynb
+++ b/Python_Stock/Technical_Indicators/Median_Price.ipynb
@@ -17,8 +17,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Minimum_Price.ipynb
+++ b/Python_Stock/Technical_Indicators/Minimum_Price.ipynb
@@ -17,8 +17,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Momentum.ipynb
+++ b/Python_Stock/Technical_Indicators/Momentum.ipynb
@@ -26,8 +26,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Momentum2.ipynb
+++ b/Python_Stock/Technical_Indicators/Momentum2.ipynb
@@ -17,8 +17,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Moving_Average_Envelopes.ipynb
+++ b/Python_Stock/Technical_Indicators/Moving_Average_Envelopes.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Moving_Average_High_Low.ipynb
+++ b/Python_Stock/Technical_Indicators/Moving_Average_High_Low.ipynb
@@ -17,8 +17,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Moving_Average_Ribbon.ipynb
+++ b/Python_Stock/Technical_Indicators/Moving_Average_Ribbon.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Moving_Correlation_Coefficient.ipynb
+++ b/Python_Stock/Technical_Indicators/Moving_Correlation_Coefficient.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Moving_Covariance.ipynb
+++ b/Python_Stock/Technical_Indicators/Moving_Covariance.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Moving_Dispersion.ipynb
+++ b/Python_Stock/Technical_Indicators/Moving_Dispersion.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Moving_Linear_Regression.ipynb
+++ b/Python_Stock/Technical_Indicators/Moving_Linear_Regression.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Moving_Maximum.ipynb
+++ b/Python_Stock/Technical_Indicators/Moving_Maximum.ipynb
@@ -17,8 +17,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Moving_Median.ipynb
+++ b/Python_Stock/Technical_Indicators/Moving_Median.ipynb
@@ -17,8 +17,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Moving_Minimum.ipynb
+++ b/Python_Stock/Technical_Indicators/Moving_Minimum.ipynb
@@ -17,8 +17,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Moving_Standard_Deviation.ipynb
+++ b/Python_Stock/Technical_Indicators/Moving_Standard_Deviation.ipynb
@@ -17,8 +17,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Moving_Standard_Error.ipynb
+++ b/Python_Stock/Technical_Indicators/Moving_Standard_Error.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Moving_Summation.ipynb
+++ b/Python_Stock/Technical_Indicators/Moving_Summation.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/NATR.ipynb
+++ b/Python_Stock/Technical_Indicators/NATR.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/NVI.ipynb
+++ b/Python_Stock/Technical_Indicators/NVI.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/NVI2.ipynb
+++ b/Python_Stock/Technical_Indicators/NVI2.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/New_Highs_New_Lows.ipynb
+++ b/Python_Stock/Technical_Indicators/New_Highs_New_Lows.ipynb
@@ -28,8 +28,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/PGO.ipynb
+++ b/Python_Stock/Technical_Indicators/PGO.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/PMO.ipynb
+++ b/Python_Stock/Technical_Indicators/PMO.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/PVI.ipynb
+++ b/Python_Stock/Technical_Indicators/PVI.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/PVT.ipynb
+++ b/Python_Stock/Technical_Indicators/PVT.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/PivotPoint.ipynb
+++ b/Python_Stock/Technical_Indicators/PivotPoint.ipynb
@@ -27,8 +27,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\") \n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Price_Channels.ipynb
+++ b/Python_Stock/Technical_Indicators/Price_Channels.ipynb
@@ -17,8 +17,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Price_Relative.ipynb
+++ b/Python_Stock/Technical_Indicators/Price_Relative.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Qstick.ipynb
+++ b/Python_Stock/Technical_Indicators/Qstick.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/ROC.ipynb
+++ b/Python_Stock/Technical_Indicators/ROC.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/ROC100.ipynb
+++ b/Python_Stock/Technical_Indicators/ROC100.ipynb
@@ -24,7 +24,7 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
+        "# yfinance is used to fetch data \n",
         "import yfinance as yf\n",
         "yf.pdr_override()"
       ],

--- a/Python_Stock/Technical_Indicators/ROCP.ipynb
+++ b/Python_Stock/Technical_Indicators/ROCP.ipynb
@@ -24,7 +24,7 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
+        "# yfinance is used to fetch data \n",
         "import yfinance as yf\n",
         "yf.pdr_override()"
       ],

--- a/Python_Stock/Technical_Indicators/ROI.ipynb
+++ b/Python_Stock/Technical_Indicators/ROI.ipynb
@@ -26,8 +26,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/RSI.ipynb
+++ b/Python_Stock/Technical_Indicators/RSI.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/RSI2.ipynb
+++ b/Python_Stock/Technical_Indicators/RSI2.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/RSI_BollingerBands.ipynb
+++ b/Python_Stock/Technical_Indicators/RSI_BollingerBands.ipynb
@@ -17,8 +17,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Rainbow_Charts.ipynb
+++ b/Python_Stock/Technical_Indicators/Rainbow_Charts.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Realised_Volatility.ipynb
+++ b/Python_Stock/Technical_Indicators/Realised_Volatility.ipynb
@@ -25,8 +25,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Relative_Volatility_Index.ipynb
+++ b/Python_Stock/Technical_Indicators/Relative_Volatility_Index.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/SMA.ipynb
+++ b/Python_Stock/Technical_Indicators/SMA.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/SMMA.ipynb
+++ b/Python_Stock/Technical_Indicators/SMMA.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Smoothed_Moving_Average.ipynb
+++ b/Python_Stock/Technical_Indicators/Smoothed_Moving_Average.ipynb
@@ -26,8 +26,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Speed_Resistance_Lines.ipynb
+++ b/Python_Stock/Technical_Indicators/Speed_Resistance_Lines.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Standard_Deviation_Volatility.ipynb
+++ b/Python_Stock/Technical_Indicators/Standard_Deviation_Volatility.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Stochastic_Fast.ipynb
+++ b/Python_Stock/Technical_Indicators/Stochastic_Fast.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Stochastic_Full.ipynb
+++ b/Python_Stock/Technical_Indicators/Stochastic_Full.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Stochastic_RSI.ipynb
+++ b/Python_Stock/Technical_Indicators/Stochastic_RSI.ipynb
@@ -25,8 +25,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Stochastic_Slow.ipynb
+++ b/Python_Stock/Technical_Indicators/Stochastic_Slow.ipynb
@@ -17,8 +17,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/SuperTrend.ipynb
+++ b/Python_Stock/Technical_Indicators/SuperTrend.ipynb
@@ -25,8 +25,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/T3_Moving_Average.ipynb
+++ b/Python_Stock/Technical_Indicators/T3_Moving_Average.ipynb
@@ -17,8 +17,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/TEMA.ipynb
+++ b/Python_Stock/Technical_Indicators/TEMA.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/TRIMA.ipynb
+++ b/Python_Stock/Technical_Indicators/TRIMA.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/TRIX.ipynb
+++ b/Python_Stock/Technical_Indicators/TRIX.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/TWAP.ipynb
+++ b/Python_Stock/Technical_Indicators/TWAP.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Tenkan_Sen.ipynb
+++ b/Python_Stock/Technical_Indicators/Tenkan_Sen.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Tirone_Levels.ipynb
+++ b/Python_Stock/Technical_Indicators/Tirone_Levels.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/True_Strength_Index.ipynb
+++ b/Python_Stock/Technical_Indicators/True_Strength_Index.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Typical_Price.ipynb
+++ b/Python_Stock/Technical_Indicators/Typical_Price.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Ulcer_Index.ipynb
+++ b/Python_Stock/Technical_Indicators/Ulcer_Index.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Ultimate_Oscillator.ipynb
+++ b/Python_Stock/Technical_Indicators/Ultimate_Oscillator.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/VAO.ipynb
+++ b/Python_Stock/Technical_Indicators/VAO.ipynb
@@ -25,8 +25,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/VPT.ipynb
+++ b/Python_Stock/Technical_Indicators/VPT.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/VWAP.ipynb
+++ b/Python_Stock/Technical_Indicators/VWAP.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Variance_Indicator.ipynb
+++ b/Python_Stock/Technical_Indicators/Variance_Indicator.ipynb
@@ -17,8 +17,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Volume_Price_Confirmation_Indicator.ipynb
+++ b/Python_Stock/Technical_Indicators/Volume_Price_Confirmation_Indicator.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Volume_Weighted_Moving_Average.ipynb
+++ b/Python_Stock/Technical_Indicators/Volume_Weighted_Moving_Average.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Vortex_Indicator.ipynb
+++ b/Python_Stock/Technical_Indicators/Vortex_Indicator.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/WMA.ipynb
+++ b/Python_Stock/Technical_Indicators/WMA.ipynb
@@ -17,8 +17,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/WSMA.ipynb
+++ b/Python_Stock/Technical_Indicators/WSMA.ipynb
@@ -25,8 +25,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/WWS.ipynb
+++ b/Python_Stock/Technical_Indicators/WWS.ipynb
@@ -25,8 +25,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/WilliamR.ipynb
+++ b/Python_Stock/Technical_Indicators/WilliamR.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/ZLEMA.ipynb
+++ b/Python_Stock/Technical_Indicators/ZLEMA.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/Z_Score_Indicator.ipynb
+++ b/Python_Stock/Technical_Indicators/Z_Score_Indicator.ipynb
@@ -17,8 +17,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Technical_Indicators/ZigZag.ipynb
+++ b/Python_Stock/Technical_Indicators/ZigZag.ipynb
@@ -24,8 +24,8 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "# fix_yahoo_finance is used to fetch data \n",
-        "import fix_yahoo_finance as yf\n",
+        "# yfinance is used to fetch data \n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/Two_Stock_Comparing_Dividend.ipynb
+++ b/Python_Stock/Two_Stock_Comparing_Dividend.ipynb
@@ -42,7 +42,7 @@
         "import warnings\n",
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
-        "import fix_yahoo_finance as yf\n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],

--- a/Python_Stock/ValueAtRisk.ipynb
+++ b/Python_Stock/ValueAtRisk.ipynb
@@ -19,7 +19,7 @@
         "warnings.filterwarnings(\"ignore\")\n",
         "\n",
         "from pandas_datareader import data as pdr\n",
-        "import fix_yahoo_finance as yf\n",
+        "import yfinance as yf\n",
         "yf.pdr_override()"
       ],
       "outputs": [],


### PR DESCRIPTION
The fix-yahoo-finance Python library has been renamed to yfinance, so I updated the notebooks to reflect the change.
I haven't checked every modified notebook, but most appear to be functioning as intended.